### PR TITLE
Set PGs to 1 if 0

### DIFF
--- a/distrac/create-pool.sh
+++ b/distrac/create-pool.sh
@@ -29,6 +29,11 @@ amountOfOSDs=`cat $folder/amountOfOSDs.num`
 
 # Gets current PGS in ceph
 currentPGs=$(ceph pg stat 2> /dev/null | awk '{print $1}')
+if [ "$currentPGs" -eq "0" ];
+then
+    currentPGs=1
+fi 
+
 source calculate-pool-pg.sh
 # Works out the PGs need for pool
 CalculatePoolPG $percentage $amountOfHosts $amountOfOSDs
@@ -37,9 +42,15 @@ ceph osd pool create $poolname $result
 echo "Creating PG's"
 # Update the expected PGs active and clean to current plus new
 result=$(expr $result + $currentPGs)
+resultMinus1=$(expr $result - 1)
+resultPlus1=$(expr $result + 1) 
 # Check if all pgs are active and clean
 pgstat=$(ceph pg stat 2> /dev/null | grep -c "$result active+clean")
 while  [ $pgstat -le 0 ]
 do
+    echo "hi"
 	pgstat=$(ceph pg stat 2> /dev/null | grep -c "$result active+clean")
+    echo "bye"
+    pgstat=$(ceph pg stat 2> /dev/null | grep -c "$resultPlus1 active+clean")
+    echo "no"
 done


### PR DESCRIPTION
In new versions of Ceph, a pool is created at the start, this is not always created straight away however it has a pool size of 1, so if PGs is 0, the value is changed to 1.