### PR TITLE
Fixing create-pool

### DIFF
--- a/distrac/create-pool.sh
+++ b/distrac/create-pool.sh
@@ -42,11 +42,9 @@ ceph osd pool create $poolname $result
 echo "Creating PG's"
 # Update the expected PGs active and clean to current plus new
 result=$(expr $result + $currentPGs)
-resultMinus1=$(expr $result - 1)
-resultPlus1=$(expr $result + 1) 
 # Check if all pgs are active and clean
-pgstat=$(ceph pg stat 2> /dev/null | grep -c "$result active+clean")
+pgstat=$(ceph -s | grep -c "$result active+clean")
 while  [ $pgstat -le 0 ]
 do
-	pgstat=$(ceph pg stat 2> /dev/null | grep -c "$result active+clean")
+	pgstat=$(ceph -s | grep -c "$result active+clean")
 done


### PR DESCRIPTION
When `ceph pg stat` states that all pgs are allocated, this was not the case. Therefore, the command has switched to `ceph -s` as this gives the most accurate representation of the cluster state.