### PR TITLE
Osd deployment speedup

### DIFF
--- a/distrac/create-osd.sh
+++ b/distrac/create-osd.sh
@@ -47,4 +47,4 @@ for num in $(seq 0 $[amount-1])
 do
     sudo ceph-volume --log-path /dev/null lvm prepare --data /dev/$type$num
 done
-sudo ceph-volume lvm activate --all
+sudo ceph-volume --log-path /dev/null lvm activate --all

--- a/distrac/create-osd.sh
+++ b/distrac/create-osd.sh
@@ -43,9 +43,8 @@ elif [ $type == zram ]
     create-zram.sh -s=$size -n=$amount -f=$folder
 fi
 
-# Creating OSDs using ceph-volume
 for num in $(seq 0 $[amount-1])
 do
-    sudo ceph-volume --log-path /dev/null lvm create --data /dev/$type$num
+    sudo ceph-volume --log-path /dev/null lvm prepare --data /dev/$type$num
 done
-
+sudo ceph-volume lvm activate --all

--- a/sudoers_file/distrac
+++ b/sudoers_file/distrac
@@ -42,10 +42,10 @@
 %distrac ALL=NOPASSWD: /usr/bin/cp */ceph.client.admin.keyring /etc/ceph/
 %distrac ALL=NOPASSWD: /usr/bin/cp */ceph.conf /etc/ceph/
 %distrac ALL=NOPASSWD: /usr/bin/cp */ceph.bootstrap-osd.keyring  /var/lib/ceph/bootstrap-osd/ceph.keyring
-%distrac ALL=NOPASSWD: /usr/sbin/ceph-volume --log-path /dev/null lvm create --data /dev/ram*
-%distrac ALL=NOPASSWD: /usr/sbin/ceph-volume --log-path /dev/null lvm create --data /dev/zram*
-%distrac ALL=NOPASSWD: /usr/sbin/ceph-volume --log-path /dev/null lvm create --data /dev/gram*
-
+%distrac ALL=NOPASSWD: /usr/sbin/ceph-volume --log-path /dev/null lvm prepare --data /dev/ram*
+%distrac ALL=NOPASSWD: /usr/sbin/ceph-volume --log-path /dev/null lvm prepare --data /dev/zram*
+%distrac ALL=NOPASSWD: /usr/sbin/ceph-volume --log-path /dev/null lvm prepare --data /dev/gram*
+%distrac ALL=NOPASSWD: /usr/sbin/ceph-volume --log-path /dev/null lvm activate --all 
 # Create RGW
 %distrac ALL=NOPASSWD: /usr/bin/mkdir /var/lib/ceph/radosgw/ceph-radosgw.*
 %distrac ALL=NOPASSWD: /usr/bin/cp */ceph.client.radosgw.keyring /var/lib/ceph/radosgw/ceph-radosgw.*/keyring


### PR DESCRIPTION
ceph-volume lvm create` runs in the background, prepare and activate. However, activate can be used to start all OSDs once prepared, which is faster than sequentially using create, as some OSDs will activate on their own if left in a prepared state for long enough. Thus the change.